### PR TITLE
Fix CPU usage 100%

### DIFF
--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -54,6 +54,7 @@ void CSF::setPointCloud(std::vector<csf::Point> points) {
     point_cloud.resize(points.size());
 
     int pointCount = static_cast<int>(points.size());
+    omp_set_num_threads(NUM_THREAD);
     #pragma omp parallel for
     for (int i = 0; i < pointCount; i++) {
         csf::Point las;
@@ -79,6 +80,7 @@ void CSF::setPointCloud(double *points, int rows) {
 void CSF::setPointCloud(csf::PointCloud& pc) {
     point_cloud.resize(pc.size());
     int pointCount = static_cast<int>(pc.size());
+    omp_set_num_threads(NUM_THREAD);
     #pragma omp parallel for
     for (int i = 0; i < pointCount; i++) {
         csf::Point las;
@@ -92,6 +94,7 @@ void CSF::setPointCloud(csf::PointCloud& pc) {
 void CSF::setPointCloud(std::vector<std::vector<float> > points) {
     point_cloud.resize(points.size());
     int pointCount = static_cast<int>(points.size());
+    omp_set_num_threads(NUM_THREAD);
     #pragma omp parallel for
     for (int i = 0; i < pointCount; i++) {
         csf::Point las;

--- a/src/Cloth.cpp
+++ b/src/Cloth.cpp
@@ -96,6 +96,7 @@ Cloth::Cloth(const Vec3& _origin_pos,
 
 double Cloth::timeStep() {
     int particleCount = static_cast<int>(particles.size());
+    omp_set_num_threads(NUM_THREAD);
     #pragma omp parallel for
     for (int i = 0; i < particleCount; i++) {
         particles[i].timeStep();
@@ -128,6 +129,7 @@ void Cloth::addForce(const Vec3 direction) {
 
 void Cloth::terrCollision() {
     int particleCount = static_cast<int>(particles.size());
+    omp_set_num_threads(NUM_THREAD);
     #pragma omp parallel for
     for (int i = 0; i < particleCount; i++) {
         Vec3 v = particles[i].getPos();

--- a/src/Cloth.h
+++ b/src/Cloth.h
@@ -58,6 +58,7 @@
 // #include <boost/progress.hpp>
 // post processing is only for connected component which is large than 50
 #define MAX_PARTICLE_FOR_POSTPROCESSIN    50
+#define NUM_THREAD 6
 
 struct XY {
     XY(int x1, int y1) {


### PR DESCRIPTION
<!---
Pull Request Template
- Please fill the sections below as described in the comments.
- This information simplifies collaboration and helps future readers.
- Reviewers should ask for this info to be filled when missing.
-->

<!---
PR Metadata
- Title: Provide a short summary of the PR changes.
- Assignees: Assign yourself and other direct collaborators.
- Type: Create the PR as a draft. Only set it to non-draft when it is ready to be reviewed.
- Reviewers: Only assign reviewers when the PR is ready to be reviewed.
- Labels: Only assign labels with high priority and important context. Default is label-less.
-->

### Description
<!--- Describe your changes in detail -->
<!--- If there are other links relevant to this PR, mention them here as well -->
- use omp_set_num_threads to limit number of threads allowed to be used


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Cloth simulation used 100% of CPU Power

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Readers can use this info to verify or try the changes. -->
<!--- - Code snippet with the commands you used to test this locally. -->
<!--- - Link to relevant CI run. -->
<!--- - Other useful info for reviewers. -->
This test uses the E2E setup in [caisson_ros_pkg](https://github.com/DeepX-inc/caisson_ros_pkg/blob/main/docs/E2E.md). Please make sure you update the caisson_ros_pkg repo and Talos repo.
1. Before the changes
```bash
# Command in server
docker-compose -f ~/caisson_ws/repos/caisson_ros_pkg/docker/system/tsukuba.yml pull
docker-compose -f ~/caisson_ws/repos/caisson_ros_pkg/docker/system/tsukuba.yml up -d
. ~/caisson_ws/repos/caisson_ros_pkg/docker/system/scripts/tsukuba_simulation.bash

# Press Enter for all the window in tmux
```
```
# Command in 6082 Simulator VNC
ros2 launch oliver_ros_interface techfarm_caisson_launch.py rviz:=False
```
```
# Another Terminal in server
htop
```
The htop should show all CPU at close to 100%.
Please Ctrl + C all the windows in tmux only.

<img width="1226" alt="Screen Shot 2022-12-27 at 12 58 48" src="https://user-images.githubusercontent.com/103618314/209610036-eacff931-ba9e-4444-a172-05330b18fc98.png">


2. Apply the changes
```
# Terminal in server
docker exec -it system /bin/bash
cd /home/docker/base
rm -rf CSF
git clone -b fix/all-cpu-100% git@github.com:DeepX-inc/CSF.git
mkdir -p CSF/build && cd CSF/build \
  && cmake -DBUILD_SHARED_LIBS=ON .. && make -j$(nproc) && make install -j$(nproc) && make clean

# Close terminal
```

3. After the changes
- Please go to the tmux terminal and use the all 4 previous commands in windows to start the system.
- The htop should show normal CPU usage.
- Use GeoViz and Simulation to check whether the height map is working.

<img width="1226" alt="Screen Shot 2022-12-27 at 12 59 29" src="https://user-images.githubusercontent.com/103618314/209610051-8e6beffc-ad8e-4741-bf49-21ae459e638f.png">

### Checklist
<!--- Put an `x` in the boxes that apply. -->

- [x] Have you filled the sections above?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same GitHub Issues/ClickUp Task(s)?
- [x] Have you documented the changes in GitHub Issues and/or ClickUp Task(s) related to this Pull Request?
- [x] Have you added labels, where appropriate, to this Pull Request?

<!--
Do not include screenshots.
- These will be accessible from everyone outside DeepX-inc.
- Add them to the ClickUp task instead.
-->