### PR TITLE
Disable periodic debug logs by default

### DIFF
--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -50,6 +50,16 @@ CSF::CSF() {
 CSF::~CSF()
 {}
 
+void CSF::setEnableLogging(bool enable) {
+    is_logging_enabled = enable;
+}
+
+void CSF::log(const std::string& message) {
+    if (is_logging_enabled) {
+        std::cout << "[CSF]" << message << std::endl;
+    }
+}
+
 void CSF::setPointCloud(std::vector<csf::Point> points) {
     point_cloud.resize(points.size());
 
@@ -115,7 +125,11 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
                        std::vector<int>& offGroundIndexes,
                        bool              exportCloth) {
     // Terrain
-    // std::cout << "[" << this->index << "] Configuring terrain..." << std::endl;
+    std::stringstream ss;
+    ss.str("");
+    ss << "[do_filtering] [" << this->index << "] Configuring terrain...";
+    log(ss.str());
+
     csf::Point bbMin, bbMax;
     point_cloud.computeBoundingBox(bbMin, bbMax);
 
@@ -136,9 +150,10 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
         std::floor((bbMax.z - bbMin.z) / params.cloth_resolution)
     ) + 2 * clothbuffer_d;
 
-    // std::cout << "[" << this->index << "] Configuring cloth..." << std::endl;
-    // std::cout << "[" << this->index << "]  - width: " << width_num << " "
-    //      << "height: " << height_num << std::endl;
+    ss.str("");
+    ss << "[do_filtering] [" << this->index << "] Configuring cloth ";
+    ss << "with (w,h)=(" << width_num << "," << height_num << ") ...";
+    log(ss.str());
 
     Cloth cloth(
         origin_pos,
@@ -152,13 +167,17 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
         params.time_step
     );
 
-    // std::cout << "[" << this->index << "] Rasterizing..." << std::endl;
+    ss.str("");
+    ss << "[do_filtering] [" << this->index << "] Rasterizing...";
+    log(ss.str());
     Rasterization::RasterTerrian(cloth, point_cloud, cloth.getHeightvals());
 
     double time_step2 = params.time_step * params.time_step;
     double gravity    = 0.2;
 
-    // std::cout << "[" << this->index << "] Simulating..." << std::endl;
+    ss.str("");
+    ss << "[do_filtering] [" << this->index << "] Simulating...";
+    log(ss.str());
     cloth.addForce(Vec3(0, -gravity, 0) * time_step2);
 
     // boost::progress_display pd(params.interations);
@@ -174,7 +193,9 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
     }
 
     if (params.bSloopSmooth) {
-        // std::cout << "[" << this->index << "]  - post handle..." << std::endl;
+        ss.str("");
+        ss << "[do_filtering] [" << this->index << "] Post handle...";
+        log(ss.str());
         cloth.movableFilter();
     }
 

--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -115,7 +115,7 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
                        std::vector<int>& offGroundIndexes,
                        bool              exportCloth) {
     // Terrain
-    std::cout << "[" << this->index << "] Configuring terrain..." << std::endl;
+    // std::cout << "[" << this->index << "] Configuring terrain..." << std::endl;
     csf::Point bbMin, bbMax;
     point_cloud.computeBoundingBox(bbMin, bbMax);
 
@@ -136,9 +136,9 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
         std::floor((bbMax.z - bbMin.z) / params.cloth_resolution)
     ) + 2 * clothbuffer_d;
 
-    std::cout << "[" << this->index << "] Configuring cloth..." << std::endl;
-    std::cout << "[" << this->index << "]  - width: " << width_num << " "
-         << "height: " << height_num << std::endl;
+    // std::cout << "[" << this->index << "] Configuring cloth..." << std::endl;
+    // std::cout << "[" << this->index << "]  - width: " << width_num << " "
+    //      << "height: " << height_num << std::endl;
 
     Cloth cloth(
         origin_pos,
@@ -152,13 +152,13 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
         params.time_step
     );
 
-    std::cout << "[" << this->index << "] Rasterizing..." << std::endl;
+    // std::cout << "[" << this->index << "] Rasterizing..." << std::endl;
     Rasterization::RasterTerrian(cloth, point_cloud, cloth.getHeightvals());
 
     double time_step2 = params.time_step * params.time_step;
     double gravity    = 0.2;
 
-    std::cout << "[" << this->index << "] Simulating..." << std::endl;
+    // std::cout << "[" << this->index << "] Simulating..." << std::endl;
     cloth.addForce(Vec3(0, -gravity, 0) * time_step2);
 
     // boost::progress_display pd(params.interations);
@@ -174,7 +174,7 @@ void CSF::do_filtering(std::vector<int>& groundIndexes,
     }
 
     if (params.bSloopSmooth) {
-        std::cout << "[" << this->index << "]  - post handle..." << std::endl;
+        // std::cout << "[" << this->index << "]  - post handle..." << std::endl;
         cloth.movableFilter();
     }
 

--- a/src/CSF.h
+++ b/src/CSF.h
@@ -70,6 +70,12 @@ public:
     CSF();
     ~CSF();
 
+    // enable debug logs
+    void setEnableLogging(bool enable);
+
+    // conditional log based on setEnableLogging
+    void log(const std::string& message);
+
     // set pointcloud from vector
     void setPointCloud(std::vector<csf::Point> points);
     // set point cloud from a one-dimentional array. it defines a N*3 point cloud by the given rows.
@@ -107,6 +113,7 @@ public:
                       bool              exportCloth = false);
 
 private:
+    bool is_logging_enabled{false};
 
 #ifdef _CSF_DLL_EXPORT_
     class __declspec (dllexport)csf::PointCloud point_cloud;


### PR DESCRIPTION
### Description

Add configuration to enable or disable the logs on runtime.

If enabled, it will display logs like:
```
1705313514.3751209 [node-name] [CSF][do_filtering] [0] Configuring terrain...
1705313514.3755646 [node-name] [CSF][do_filtering] [0] Configuring cloth with (w,h)=(58,75) ...
1705313514.3870096 [node-name] [CSF][do_filtering] [0] Rasterizing...
1705313514.3887200 [node-name] [CSF][do_filtering] [0] Simulating...
1705313514.3996294 [node-name] [CSF][do_filtering] [0] Post handle...
```

### Motivation and Context

These logs are displayed for every perception spin (e.g. 10Hz), making all other logs unreadable.

Example of original logs for every spin:
```
1704824061.2610149 [node-name] [0] Configuring terrain...
1704824061.2619231 [node-name] [0] Configuring cloth...
1704824061.2621562 [node-name] [0]  - width: 58 height: 76
1704824061.2780621 [node-name] [0] Rasterizing...
1704824061.2797780 [node-name] [0] Simulating...
1704824061.2888267 [node-name] [0]  - post handle...
```

### How Has This Been Tested?

- [x] Built CSF locally with `is_logging_enabled` as `false` and `true`, then checked it by running the perception pipeline.
- [x] Integrate the feature in the perception pipeline.

```bash
cd /home/docker/base/CSF/
mkdir -p build && cd build
cmake -DBUILD_SHARED_LIBS=ON ..
make -j$(nproc)
make install -j$(nproc)
make clean
```
