### PR TITLE
Feature: Enable fPIC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(src)
 
 option(BUILD_DEMO "Build csfdemo executable" OFF)
 set(BUILD_SHARED_LIBS "Build as shared library" OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(BUILD_DEMO)
   add_subdirectory(CSFDemo)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 3.10)
 project(CSF LANGUAGES CXX)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 find_package(OpenMP)
 
 add_subdirectory(src)
 
 option(BUILD_DEMO "Build csfdemo executable" OFF)
 set(BUILD_SHARED_LIBS "Build as shared library" OFF)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(BUILD_DEMO)
   add_subdirectory(CSFDemo)


### PR DESCRIPTION
We have an issue with compiling CSF with Orion, as Orion requires fPIC to be enabled. 


## How this has been tested
Together with orion, I checked that this does not cause issue.